### PR TITLE
add topic filtering and realtime subscriptions

### DIFF
--- a/examples/whale_bot.py
+++ b/examples/whale_bot.py
@@ -13,13 +13,10 @@ from tweepy.client import Client
 
 from emp_hooks import log, manager, onchain
 
-
-def get_eth_price():
-    eth_address = ChainlinkPriceOracle.Ethereum.ETH
-    eth_price_feed = ETHUSDPriceFeed[Ethereum](address=eth_address)
-    price = eth_price_feed.latest_round_data().get(sync=True)
-    return price.answer / 1e8
-
+ETH_ADDRESS = HexAddress(HexStr("0x4200000000000000000000000000000000000006"))
+ETH_PRICE: float = -1.0
+token_cache = {}
+symbol_cache = {}
 
 # Configure logging
 log.setLevel(logging.DEBUG)
@@ -27,6 +24,14 @@ stream_handler = logging.StreamHandler()
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 stream_handler.setFormatter(formatter)
 log.addHandler(stream_handler)
+
+
+def get_eth_price():
+    eth_address = ChainlinkPriceOracle.Ethereum.ETH
+    eth_price_feed = ETHUSDPriceFeed[Ethereum](address=eth_address)
+    price = eth_price_feed.latest_round_data().get(sync=True)
+    return price.answer / 1e8
+
 
 if os.environ.get("ENVIRONMENT", "").lower() == "production":
     client = Client(
@@ -39,16 +44,11 @@ if os.environ.get("ENVIRONMENT", "").lower() == "production":
 else:
     # create a printer class to mimick tweeting for testing
 
-    class Printer:
+    class TwitterMock:
         def create_tweet(self, text: str):
             print("TWEET:", text)
 
-    client = Printer()
-
-ETH_ADDRESS = HexAddress(HexStr("0x4200000000000000000000000000000000000006"))
-ETH_PRICE: float = -1.0
-token_cache = {}
-symbol_cache = {}
+    client = TwitterMock()
 
 
 @onchain.on_event(

--- a/examples/whale_bot.py
+++ b/examples/whale_bot.py
@@ -15,6 +15,7 @@ from emp_hooks import log, manager, onchain
 
 ETH_ADDRESS = HexAddress(HexStr("0x4200000000000000000000000000000000000006"))
 ETH_PRICE: float = -1.0
+BIG_BUY_LIMIT: int = 10_000
 token_cache = {}
 symbol_cache = {}
 
@@ -119,7 +120,7 @@ def log_eth_price(event_data: EventData[V3SwapEventType]):
             event_data.log.transaction_hash,
         )
 
-    if buy_amount > 10_000:
+    if buy_amount > BIG_BUY_LIMIT:
         client.create_tweet(
             text=dedent(
                 f"""
@@ -131,7 +132,7 @@ def log_eth_price(event_data: EventData[V3SwapEventType]):
         """
             )
         )
-    elif sell_amount > 10_000:
+    elif sell_amount > BIG_BUY_LIMIT:
         client.create_tweet(
             text=dedent(
                 f"""

--- a/examples/whale_bot.py
+++ b/examples/whale_bot.py
@@ -1,0 +1,142 @@
+import logging
+import os
+from textwrap import dedent
+
+from eth_rpc import EventData
+from eth_rpc.networks import Base, Ethereum
+from eth_typeshed.chainlink.eth_usd_feed import ChainlinkPriceOracle, ETHUSDPriceFeed
+from eth_typeshed.erc20 import ERC20
+from eth_typeshed.uniswap_v3.events import V3SwapEvent, V3SwapEventType
+from eth_typeshed.uniswap_v3.pool import UniswapV3Pool
+from tweepy.client import Client
+
+from emp_hooks import log, manager, onchain
+
+
+def get_eth_price():
+    eth_address = ChainlinkPriceOracle.Ethereum.ETH
+    eth_price_feed = ETHUSDPriceFeed[Ethereum](address=eth_address)
+    price = eth_price_feed.latest_round_data().get(sync=True)
+    return price.answer / 1e8
+
+
+# Configure logging
+log.setLevel(logging.DEBUG)
+stream_handler = logging.StreamHandler()
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+stream_handler.setFormatter(formatter)
+log.addHandler(stream_handler)
+
+if os.environ.get("ENVIRONMENT", "").lower() == "production":
+    client = Client(
+        bearer_token=os.environ["TWITTER_BEARER_TOKEN"],
+        consumer_key=os.environ["TWITTER_CONSUMER_KEY"],
+        consumer_secret=os.environ["TWITTER_CONSUMER_SECRET"],
+        access_token=os.environ["TWITTER_ACCESS_TOKEN"],
+        access_token_secret=os.environ["TWITTER_ACCESS_TOKEN_SECRET"],
+    )
+else:
+    # create a printer class to mimick tweeting for testing
+
+    class Printer:
+        def create_tweet(self, text: str):
+            print("TWEET:", text)
+
+    client = Printer()
+
+ETH_PRICE: float = -1.0
+token_cache = {}
+symbol_cache = {}
+
+
+@onchain.on_event(
+    V3SwapEvent,
+    Base,
+    # forces the start block to be overwritten, otherwise resumes from the last checkpoint
+    force_set_block=True,
+    subscribe=True,
+)
+def log_eth_price(event_data: EventData[V3SwapEventType]):
+    global ETH_PRICE
+    if ETH_PRICE == -1.0:
+        ETH_PRICE = get_eth_price()
+        log.debug("Initial ETH Price: %s", ETH_PRICE)
+
+    event = event_data.event
+    address = event_data.log.address
+    amount0 = event.amount0
+    amount1 = event.amount1
+
+    pool = UniswapV3Pool[Base](address=address)
+    if address not in token_cache:
+        token0 = pool.token0().get(sync=True)
+        token1 = pool.token1().get(sync=True)
+        token_cache[address] = (token0, token1)
+
+    token0, token1 = token_cache[address]
+
+    if address == "0xb4CB800910B228ED3d0834cF79D697127BBB00e5":
+        _amount0 = amount0 / 1e18
+        _amount1 = amount1 / 1e6
+        ETH_PRICE = abs(_amount1 / _amount0)
+        log.debug("ETH Price: %s", ETH_PRICE)
+
+    token_symbol: str
+    buy_amount: float = 0.0
+    sell_amount: float = 0.0
+
+    if token0 == "0x4200000000000000000000000000000000000006":
+        if token1 not in symbol_cache:
+            token_symbol = ERC20[Base](address=token1).symbol().get(sync=True)
+            symbol_cache[token1] = token_symbol
+
+        token_symbol = symbol_cache[token1]
+        if amount0 > 0:
+            buy_amount = abs(amount0 / 1e18 * ETH_PRICE)
+        else:
+            sell_amount = abs(amount0 / 1e18 * ETH_PRICE)
+    elif token1 == "0x4200000000000000000000000000000000000006":
+        if token0 not in symbol_cache:
+            token_symbol = ERC20[Base](address=token0).symbol().get(sync=True)
+            symbol_cache[token0] = token_symbol
+        token_symbol = symbol_cache[token0]
+        if amount1 > 0:
+            sell_amount = abs(amount1 / 1e18 * ETH_PRICE)
+        else:
+            buy_amount = abs(amount1 / 1e18 * ETH_PRICE)
+    else:
+        return
+
+    if buy_amount > 0:
+        log.debug(
+            "Buy Amount: %s | tx_hash: %s", buy_amount, event_data.log.transaction_hash
+        )
+
+    if buy_amount > 10_000:
+        client.create_tweet(
+            text=dedent(
+                f"""
+            Large Buy
+            --------------------------------
+            ${buy_amount:,.2f} of {token_symbol}
+            token address: {address}
+            tx hash: {event_data.log.transaction_hash}
+        """
+            )
+        )
+    elif sell_amount > 10_000:
+        client.create_tweet(
+            text=dedent(
+                f"""
+            Large Sell
+            --------------------------------
+            ${sell_amount:,.2f} of {token_symbol}
+            token address: {address}
+            tx hash: {event_data.log.transaction_hash}
+        """
+            )
+        )
+
+
+if __name__ == "__main__":
+    manager.hooks.run_forever()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emp_hooks"
-version = "0.0.5"
+version = "0.0.6"
 description = "emp hooks"
 authors = [
     {name = "johnny-emp",email = "johnny@empyrealsdk.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic (>=2.10.0,<3.0.0)",
     "croniter (>=6.0.0,<7.0.0)",
     "eth-rpc-py (>=0.1.29,<0.2.0)",
+    "websockets (>=15.0.0,<16.0.0)",
 ]
 
 [build-system]

--- a/src/emp_hooks/handlers/onchain/event.py
+++ b/src/emp_hooks/handlers/onchain/event.py
@@ -2,7 +2,9 @@ import os
 from collections.abc import Callable
 
 from eth_rpc import Event, set_alchemy_key
+from eth_rpc.event import IGNORE, IGNORE_VAL
 from eth_rpc.types import BLOCK_STRINGS, HexAddress, Network
+from eth_typing import HexStr
 
 from emp_hooks.utils import DynamoKeyValueStore
 
@@ -15,6 +17,9 @@ def on_event(
     start_block: int | BLOCK_STRINGS | None = None,
     address: list[HexAddress] | HexAddress | None = None,
     addresses: list[HexAddress] = [],
+    topic1: list[HexStr] | HexStr | IGNORE = IGNORE_VAL,
+    topic2: list[HexStr] | HexStr | IGNORE = IGNORE_VAL,
+    topic3: list[HexStr] | HexStr | IGNORE = IGNORE_VAL,
     force_set_block: bool = False,
 ):
     """
@@ -26,6 +31,9 @@ def on_event(
         start_block (int | BLOCK_STRINGS | None, optional): The block number to start listening from. Defaults to None.
         address (list[HexAddress] | HexAddress | None, optional): A single address or a list of addresses to filter the event. Defaults to None.
         addresses (list[HexAddress], optional): A list of addresses to filter the event. Defaults to an empty list.
+        topic1 (list[HexStr] | HexStr | IGNORE, optional): A single topic or a list of topics to filter for topic1 on the event. Defaults to IGNORE.
+        topic2 (list[HexStr] | HexStr | IGNORE, optional): A single topic or a list of topics to filter for topic2 on the event. Defaults to IGNORE.
+        topic3 (list[HexStr] | HexStr | IGNORE, optional): A single topic or a list of topics to filter for topic3 on the event. Defaults to IGNORE.
         force_set_block (bool, optional): If True, forces the start block to be set even if an offset exists. Defaults to False.
 
     Returns:
@@ -43,7 +51,12 @@ def on_event(
             addresses.extend(address)
 
     if addresses:
-        event = event.set_filter(addresses=addresses)
+        event = event.set_filter(
+            addresses=addresses,
+            topic1=topic1,
+            topic2=topic2,
+            topic3=topic3,
+        )
 
     if (item is None and start_block is not None) or force_set_block:
         kv_store.set(f"{event.name}-{network}-offset", str(start_block))

--- a/src/emp_hooks/handlers/onchain/event.py
+++ b/src/emp_hooks/handlers/onchain/event.py
@@ -20,6 +20,7 @@ def on_event(
     topic1: list[HexStr] | HexStr | IGNORE = IGNORE_VAL,
     topic2: list[HexStr] | HexStr | IGNORE = IGNORE_VAL,
     topic3: list[HexStr] | HexStr | IGNORE = IGNORE_VAL,
+    subscribe: bool = False,
     force_set_block: bool = False,
 ):
     """
@@ -66,6 +67,7 @@ def on_event(
             func,
             event,
             network,
+            subscribe=subscribe,
         )
         return func
 

--- a/src/emp_hooks/manager.py
+++ b/src/emp_hooks/manager.py
@@ -21,11 +21,11 @@ class HooksManager(BaseModel):
         signal.signal(signal.SIGINT, self.stop)
         signal.signal(signal.SIGTERM, self.stop)
 
-        # self._main_thread = threading.Thread(
-        #     target=self.run_forever,
-        #     daemon=False,
-        # )
-        # self._main_thread.start()
+        self._main_thread = threading.Thread(
+            target=self.run_forever,
+            daemon=False,
+        )
+        self._main_thread.start()
 
         return super().model_post_init(__context)
 

--- a/src/emp_hooks/manager.py
+++ b/src/emp_hooks/manager.py
@@ -14,11 +14,18 @@ class HooksManager(BaseModel):
     hook_managers: list[Hook] = Field(default_factory=list)
     running: bool = Field(default=False)
     _stopped: threading.Event = PrivateAttr(default_factory=threading.Event)
+    _main_thread: threading.Thread = PrivateAttr()
 
     def model_post_init(self, __context):
         # call "stop" when a SIGINT or SIGTERM is sent
         signal.signal(signal.SIGINT, self.stop)
         signal.signal(signal.SIGTERM, self.stop)
+
+        # self._main_thread = threading.Thread(
+        #     target=self.run_forever,
+        #     daemon=False,
+        # )
+        # self._main_thread.start()
 
         return super().model_post_init(__context)
 


### PR DESCRIPTION
This enables subscribing realtime when you don't need to backfill.  It's useful for some use cases but during a restart it will not resume from the last consumed event.  I think this is useful when you have something that can be a little bit lossy, but you only care about the most recent events.

If you want to make sure you get all events, just start a backfill job from the latest block.  You will also probably want to use the KeyValue store to mark events you've already handled so you don't repeat invocations.